### PR TITLE
Update composer.json to fix Symfony security advisory

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
         "wikimedia/composer-merge-plugin": "^2.1.0",
         "guzzlehttp/guzzle": "7.9.3",
         "guzzlehttp/psr7": "2.7.1",
-        "symfony/process": "v7.3.0",
+        "symfony/process": "^7.3.11",
         "symfony/http-client": "v7.3.1"
     },
     "extra": {


### PR DESCRIPTION
See [This Github link](https://github.com/advisories/GHSA-r39x-jcww-82v6) for more details on the security advisory.

Currently when trying to run `composer install` with v1.1 set as a requirement, composer gives the following error:

> Problem 1
    - Root composer.json requires abantecart/ups-php 1.1.0 -> satisfiable by abantecart/ups-php[1.1.0].
    - abantecart/ups-php 1.1.0 requires symfony/process v7.3.0 -> found symfony/process[v7.3.0] but these were not loaded, because they are affected by security advisories ("PKSA-rkkf-636k-qjb3"). Go to https://packagist.org/security-advisories/ to find advisory details. To ignore the advisories, add them to the audit "ignore" config. To turn the feature off entirely, you can set "block-insecure" to false in your "audit" config.

The security advisory has been resolved in version `7.3.11` so this removes the composer error.

